### PR TITLE
Fix: markdown persist qua restart, sửa lỗi options flow

### DIFF
--- a/custom_components/zalo_bot/__init__.py
+++ b/custom_components/zalo_bot/__init__.py
@@ -144,13 +144,10 @@ async def async_setup_entry(hass, entry):
     if CONF_ENABLE_NOTIFICATIONS not in config:
         config[CONF_ENABLE_NOTIFICATIONS] = DEFAULT_ENABLE_NOTIFICATIONS
 
-    # Khởi tạo markdown config — ưu tiên giá trị đã persist từ config_entry
-    hass.data[DOMAIN][CONF_MARKDOWN_ENABLED] = config.get(
-        CONF_MARKDOWN_ENABLED, DEFAULT_MARKDOWN_ENABLED
-    )
-    hass.data[DOMAIN][CONF_MARKDOWN_COLOR] = config.get(
-        CONF_MARKDOWN_COLOR, DEFAULT_MARKDOWN_COLOR
-    )
+    # Seed default markdown vào hass.data; giá trị thật do RestoreEntity
+    # (switch Markdown / select Markdown Color) khôi phục trong async_added_to_hass
+    hass.data[DOMAIN][CONF_MARKDOWN_ENABLED] = DEFAULT_MARKDOWN_ENABLED
+    hass.data[DOMAIN][CONF_MARKDOWN_COLOR] = DEFAULT_MARKDOWN_COLOR
 
     # Khởi tạo session và các biến toàn cục
     global session, zalo_server, WWW_DIR, PUBLIC_DIR

--- a/custom_components/zalo_bot/config_flow.py
+++ b/custom_components/zalo_bot/config_flow.py
@@ -44,15 +44,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options."""
-
-    def __init__(self, config_entry):
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""

--- a/custom_components/zalo_bot/manifest.json
+++ b/custom_components/zalo_bot/manifest.json
@@ -12,5 +12,6 @@
   "requirements": [
     "requests"
   ],
+  "single_config_entry": true,
   "version": "2026.5.10"
 }

--- a/custom_components/zalo_bot/select.py
+++ b/custom_components/zalo_bot/select.py
@@ -4,6 +4,7 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from .const import CONF_MARKDOWN_COLOR, DEFAULT_MARKDOWN_COLOR, DOMAIN
 from . import get_device_info
 
@@ -20,7 +21,7 @@ async def async_setup_entry(
     async_add_entities([ZaloBotMarkdownColorSelect(hass, config_entry)])
 
 
-class ZaloBotMarkdownColorSelect(SelectEntity):
+class ZaloBotMarkdownColorSelect(SelectEntity, RestoreEntity):
     """Select entity để chọn màu cho markdown bold."""
 
     _attr_has_entity_name = True
@@ -34,15 +35,18 @@ class ZaloBotMarkdownColorSelect(SelectEntity):
         self.config_entry = config_entry
         self._attr_unique_id = f"{config_entry.entry_id}_markdown_color"
         self._attr_device_info = get_device_info()
+        self._attr_current_option = DEFAULT_MARKDOWN_COLOR
 
-    @property
-    def current_option(self) -> str:
-        return self.config_entry.data.get(CONF_MARKDOWN_COLOR, DEFAULT_MARKDOWN_COLOR)
+    async def async_added_to_hass(self) -> None:
+        """Khôi phục lựa chọn màu đã lưu sau khi restart."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None and last_state.state in COLOR_OPTIONS:
+            self._attr_current_option = last_state.state
+        self.hass.data[DOMAIN][CONF_MARKDOWN_COLOR] = self._attr_current_option
 
     async def async_select_option(self, option: str) -> None:
+        self._attr_current_option = option
         self.hass.data[DOMAIN][CONF_MARKDOWN_COLOR] = option
-        data = {**self.config_entry.data}
-        data[CONF_MARKDOWN_COLOR] = option
-        self.hass.config_entries.async_update_entry(self.config_entry, data=data)
         self.async_write_ha_state()
         _LOGGER.info("Markdown color set to: %s", option)

--- a/custom_components/zalo_bot/switch.py
+++ b/custom_components/zalo_bot/switch.py
@@ -5,6 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from .const import (
     CONF_ENABLE_NOTIFICATIONS,
     CONF_MARKDOWN_ENABLED,
@@ -65,7 +66,7 @@ class ZaloBotNotificationSwitch(SwitchEntity):
         async_dispatcher_send(self.hass, SIGNAL_NOTIFICATION_TOGGLE, self._is_on)
 
 
-class ZaloBotMarkdownSwitch(SwitchEntity):
+class ZaloBotMarkdownSwitch(SwitchEntity, RestoreEntity):
     """Switch bật/tắt định dạng markdown (**bold**, *italic*...)."""
 
     _attr_has_entity_name = True
@@ -77,22 +78,28 @@ class ZaloBotMarkdownSwitch(SwitchEntity):
         self.config_entry = config_entry
         self._attr_unique_id = f"{config_entry.entry_id}_markdown"
         self._attr_device_info = get_device_info()
+        self._is_on = DEFAULT_MARKDOWN_ENABLED
+
+    async def async_added_to_hass(self) -> None:
+        """Khôi phục trạng thái markdown đã lưu sau khi restart."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            self._is_on = last_state.state == "on"
+        self.hass.data[DOMAIN][CONF_MARKDOWN_ENABLED] = self._is_on
 
     @property
     def is_on(self) -> bool:
-        return self.config_entry.data.get(CONF_MARKDOWN_ENABLED, DEFAULT_MARKDOWN_ENABLED)
+        return self._is_on
 
     async def async_turn_on(self, *_) -> None:
-        await self._update_config(True)
+        self._is_on = True
+        self.hass.data[DOMAIN][CONF_MARKDOWN_ENABLED] = True
         self.async_write_ha_state()
+        _LOGGER.info("Markdown formatting enabled")
 
     async def async_turn_off(self, *_) -> None:
-        await self._update_config(False)
+        self._is_on = False
+        self.hass.data[DOMAIN][CONF_MARKDOWN_ENABLED] = False
         self.async_write_ha_state()
-
-    async def _update_config(self, enabled: bool) -> None:
-        data = {**self.config_entry.data}
-        data[CONF_MARKDOWN_ENABLED] = enabled
-        self.hass.data[DOMAIN][CONF_MARKDOWN_ENABLED] = enabled
-        self.hass.config_entries.async_update_entry(self.config_entry, data=data)
-        _LOGGER.info("Markdown formatting %s", "enabled" if enabled else "disabled")
+        _LOGGER.info("Markdown formatting disabled")


### PR DESCRIPTION
## Tóm tắt

- **Markdown không giữ qua restart**: switch Markdown và select Markdown Color giờ kế thừa `RestoreEntity` nên giá trị được HA tự khôi phục sau restart. Cách cũ lưu vào `config_entry.data` chỉ flush khi tắt graceful (delayed save 1s), nên restart cứng/reboot host làm mất giá trị, rơi về `none`.
- **Lỗi bấm Cấu hình**: bỏ `OptionsFlowHandler.__init__` gán `self.config_entry` — thuộc tính này nay là property read-only nên gây `AttributeError: property 'config_entry' has no setter` trên HA mới.
- **single_config_entry**: thêm vào manifest để chặn thêm entry thứ hai, tránh xung đột state markdown global.

## Test

- [ ] Đổi Markdown Color, reboot HA OS → màu giữ nguyên
- [ ] Bật/tắt switch Markdown, restart → trạng thái giữ nguyên
- [ ] Bấm Cấu hình ở integration → mở form options, không lỗi
- [ ] Không thêm được tích hợp lần 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed markdown configuration settings (color preference and enabled/disabled state) to reliably persist across Home Assistant restarts.

**Chores**
- Integration now enforces a single active configuration entry per installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->